### PR TITLE
extracted the authorization logic to a service

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,4 @@
 class ApplicationController < ActionController::API
-  # OAuth: white-list approach.
+  # OAuth: white-list approach. This includes :authorize_request!
   include Secured
 end

--- a/app/controllers/public_controller.rb
+++ b/app/controllers/public_controller.rb
@@ -1,5 +1,5 @@
 class PublicController < ApplicationController
-  skip_before_action :authenticate_request!, only: [:public]
+  skip_before_action :authorize_request!, only: [:public]
 
   def public
     render json: { message: 'You don\'t need to be authenticated to call this' }

--- a/app/services/authorization_service.rb
+++ b/app/services/authorization_service.rb
@@ -1,0 +1,21 @@
+class AuthorizationService
+  def initialize(headers = {})
+    @headers = headers
+  end
+
+  def authenticate_request!
+    verify_token
+  end
+
+  private
+
+  def http_token
+    if @headers['Authorization'].present?
+      @headers['Authorization'].split(' ').last
+    end
+  end
+
+  def verify_token
+    JsonWebToken.verify(http_token)
+  end
+end

--- a/template.rb
+++ b/template.rb
@@ -27,10 +27,19 @@ end
 
 # JsonWebToken Class
 ########################################
+# The reason we're creating the new class in app/lib rather than lib is that
+# subdirectories under app are autoloaded by default.
 run 'mkdir app/lib'
 run 'touch app/lib/json_web_token.rb'
 
 copy_and_replace 'app/lib/json_web_token.rb'
+
+# Authorization Service
+########################################
+run 'mkdir app/services'
+run 'touch app/services/authorization_service.rb'
+
+copy_and_replace 'app/services/authorization_service.rb'
 
 # Controllers
 ########################################


### PR DESCRIPTION
By extracting the authorization logic to a service, we're separating the concerns of verifying the authenticity of a JWT versus authorizing an HTTP request. The AuthorizationService grabs the access token in the Authorization HTTP Header and passes it to the JsonWebToken for verification.

With this separation of responsibility, we can limit any possible future changes to the JWT verification process to the JsonWebToken class. With the AuthorizationService in place, we were able to add an authorization check to the secured concern to be used by the controllers.